### PR TITLE
Add support for specifying `MetricTag` on a get-only property

### DIFF
--- a/src/StackExchange.Metrics/Attributes.cs
+++ b/src/StackExchange.Metrics/Attributes.cs
@@ -9,7 +9,7 @@ namespace StackExchange.Metrics
     /// <summary>
     /// Marks a field as a Bosun tag.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     public class MetricTagAttribute : Attribute
     {
         /// <summary>

--- a/src/StackExchange.Metrics/Infrastructure/MetricBase.cs
+++ b/src/StackExchange.Metrics/Infrastructure/MetricBase.cs
@@ -166,7 +166,7 @@ namespace StackExchange.Metrics.Infrastructure
 
         /// <summary>
         /// Called when metrics should be serialized to a payload. You must call <see cref="WriteValue"/> in order for anything to be serialized.
-        ///  
+        ///
         /// This is called in serial with all other metrics, so DO NOT do anything computationally expensive in this method. If you need to do expensive
         /// computations (e.g. sorting a bunch of data), do it in <see cref="PreSerialize"/> which is called in parallel prior to this method.
         /// </summary>
@@ -241,7 +241,7 @@ namespace StackExchange.Metrics.Infrastructure
             var tags = new Dictionary<string, string>();
             foreach (var tag in GetTagsList(defaultTags, tagsByTypeCache))
             {
-                var value = tag.IsFromDefault ? defaultTags[tag.Name] : tag.FieldInfo.GetValue(this)?.ToString();
+                var value = tag.IsFromDefault ? defaultTags[tag.Name] : tag.GetValue(this);
                 if (tagValueConverter != null)
                     value = tagValueConverter(tag.Name, value);
 
@@ -251,12 +251,12 @@ namespace StackExchange.Metrics.Infrastructure
                         continue;
 
                     throw new InvalidOperationException(
-                        $"null is not a valid tag value for {GetType().FullName}.{tag.FieldInfo.Name}. This tag was declared as non-optional.");
+                        $"null is not a valid tag value for {GetType().FullName}.{tag.MemberInfo.Name}. This tag was declared as non-optional.");
                 }
                 if (!MetricValidation.IsValidTagValue(value))
                 {
                     throw new InvalidOperationException(
-                        $"Invalid value for tag {GetType().FullName}.{tag.FieldInfo.Name}. \"{value}\" is not a valid tag value. " +
+                        $"Invalid value for tag {GetType().FullName}.{tag.MemberInfo.Name}. \"{value}\" is not a valid tag value. " +
                         $"Only characters in the regex class [a-zA-Z0-9\\-_./] are allowed.");
                 }
 

--- a/src/StackExchange.Metrics/Infrastructure/MetricTag.cs
+++ b/src/StackExchange.Metrics/Infrastructure/MetricTag.cs
@@ -5,11 +5,11 @@ namespace StackExchange.Metrics.Infrastructure
 {
     class MetricTag
     {
-        public readonly string Name;
-        public readonly bool IsFromDefault;
-        public readonly bool IsOptional;
-        public readonly MemberInfo MemberInfo;
-        public readonly MetricTagAttribute Attribute;
+        public string Name { get; }
+        public bool IsFromDefault { get; }
+        public bool IsOptional { get; }
+        public MemberInfo MemberInfo { get; }
+        public MetricTagAttribute Attribute { get; }
 
         /// <summary>
         /// Only use this constructor when creating a default tag.
@@ -35,20 +35,22 @@ namespace StackExchange.Metrics.Infrastructure
                             $"The MetricTag attribute can only be applied to readonly string or enum fields. {memberInfo.DeclaringType.FullName}.{memberInfo.Name} is invalid."
                         );
                     }
+
                     break;
                 case PropertyInfo propertyInfo:
-                    if (propertyInfo.SetMethod != null || (propertyInfo.PropertyType != typeof(string) && !propertyInfo.PropertyType.IsEnum))
+                    if (propertyInfo.SetMethod != null ||
+                        (propertyInfo.PropertyType != typeof(string) && !propertyInfo.PropertyType.IsEnum))
                     {
                         throw new InvalidOperationException(
                             $"The MetricTag attribute can only be applied to readonly string or enum properties. {memberInfo.DeclaringType.FullName}.{memberInfo.Name} is invalid."
                         );
                     }
+
                     break;
                 default:
                     throw new InvalidOperationException(
                         $"The MetricTag attribute can only be applied to properties or fields. {memberInfo.DeclaringType.FullName}.{memberInfo.Name} is invalid."
                     );
-
             }
 
             IsFromDefault = false;
@@ -67,6 +69,19 @@ namespace StackExchange.Metrics.Infrastructure
             {
                 throw new InvalidOperationException($"\"{Name}\" is not a valid tag name. Field: {memberInfo.DeclaringType.FullName}.{memberInfo.Name}.");
             }
+        }
+
+        public string GetValue(MetricBase metric)
+        {
+            switch (MemberInfo)
+            {
+                case PropertyInfo propertyInfo:
+                    return propertyInfo.GetValue(metric)?.ToString();
+                case FieldInfo fieldInfo:
+                    return fieldInfo.GetValue(metric)?.ToString();
+            }
+
+            return null;
         }
     }
 }

--- a/src/StackExchange.Metrics/Infrastructure/MetricTag.cs
+++ b/src/StackExchange.Metrics/Infrastructure/MetricTag.cs
@@ -8,7 +8,7 @@ namespace StackExchange.Metrics.Infrastructure
         public readonly string Name;
         public readonly bool IsFromDefault;
         public readonly bool IsOptional;
-        public readonly FieldInfo FieldInfo;
+        public readonly MemberInfo MemberInfo;
         public readonly MetricTagAttribute Attribute;
 
         /// <summary>
@@ -22,32 +22,50 @@ namespace StackExchange.Metrics.Infrastructure
         }
 
         /// <summary>
-        /// Use this constructor when instantiating from a field.
+        /// Use this constructor when instantiating from a field or property.
         /// </summary>
-        public MetricTag(FieldInfo fieldInfo, MetricTagAttribute attribute, Func<string, string> nameReplacer)
+        public MetricTag(MemberInfo memberInfo, MetricTagAttribute attribute, Func<string, string> nameReplacer)
         {
-            IsFromDefault = false;
-            IsOptional = attribute.IsOptional;
-
-            FieldInfo = fieldInfo;
-            if (!FieldInfo.IsInitOnly || (FieldInfo.FieldType != typeof(string) && !FieldInfo.FieldType.IsEnum))
+            switch (memberInfo)
             {
-                throw new InvalidOperationException(
-                    $"The BosunTag attribute can only be applied to readonly string or enum fields. {fieldInfo.DeclaringType.FullName}.{fieldInfo.Name} is invalid.");
+                case FieldInfo fieldInfo:
+                    if (!fieldInfo.IsInitOnly || (fieldInfo.FieldType != typeof(string) && !fieldInfo.FieldType.IsEnum))
+                    {
+                        throw new InvalidOperationException(
+                            $"The MetricTag attribute can only be applied to readonly string or enum fields. {memberInfo.DeclaringType.FullName}.{memberInfo.Name} is invalid."
+                        );
+                    }
+                    break;
+                case PropertyInfo propertyInfo:
+                    if (propertyInfo.SetMethod != null || (propertyInfo.PropertyType != typeof(string) && !propertyInfo.PropertyType.IsEnum))
+                    {
+                        throw new InvalidOperationException(
+                            $"The MetricTag attribute can only be applied to readonly string or enum properties. {memberInfo.DeclaringType.FullName}.{memberInfo.Name} is invalid."
+                        );
+                    }
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"The MetricTag attribute can only be applied to properties or fields. {memberInfo.DeclaringType.FullName}.{memberInfo.Name} is invalid."
+                    );
+
             }
 
+            IsFromDefault = false;
+            IsOptional = attribute.IsOptional;
+            MemberInfo = memberInfo;
             Attribute = attribute;
 
             if (attribute.Name != null)
                 Name = attribute.Name;
             else if (nameReplacer != null)
-                Name = nameReplacer(fieldInfo.Name);
+                Name = nameReplacer(memberInfo.Name);
             else
-                Name = fieldInfo.Name;
+                Name = memberInfo.Name;
 
             if (!MetricValidation.IsValidTagName(Name))
             {
-                throw new InvalidOperationException($"\"{Name}\" is not a valid Bosun Tag name. Field: {fieldInfo.DeclaringType.FullName}.{fieldInfo.Name}.");
+                throw new InvalidOperationException($"\"{Name}\" is not a valid tag name. Field: {memberInfo.DeclaringType.FullName}.{memberInfo.Name}.");
             }
         }
     }

--- a/src/StackExchange.Metrics/MetricsCollector.cs
+++ b/src/StackExchange.Metrics/MetricsCollector.cs
@@ -87,7 +87,7 @@ namespace StackExchange.Metrics
         /// from MetricBase to exclude default tags. If an inherited class has a conflicting MetricTag field, it will override the default tag value. Default
         /// tags will generally not be included in metadata.
         /// </summary>
-        public IReadOnlyDictionary<string, string> DefaultTags { get; private set; }
+        public IReadOnlyDictionary<string, string> DefaultTags { get; }
 
         /// <summary>
         /// True if <see cref="Shutdown"/> has been called on this collector.

--- a/tests/StackExchange.Metrics.Tests/MetricTagAttributeTests.cs
+++ b/tests/StackExchange.Metrics.Tests/MetricTagAttributeTests.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using StackExchange.Metrics.Infrastructure;
+using Xunit;
+
+namespace StackExchange.Metrics.Tests
+{
+    public class MetricTagAttributeTests
+    {
+        [Fact]
+        public void ReadWritePropertyThrows()
+        {
+            var metric = new MetricWithTaggedReadWriteProperty();
+            var defaultTags = ImmutableDictionary<string, string>.Empty;
+            var tagConverter = new TagValueConverterDelegate((name, value) => value);
+
+            Assert.Throws<InvalidOperationException>(
+                () => metric.GetTags(defaultTags, tagConverter, x => x,new Dictionary<Type, List<MetricTag>>())
+            );
+        }
+
+        [Fact]
+        public void ReadWriteFieldThrows()
+        {
+            var metric = new MetricWithTaggedReadWriteField();
+            var defaultTags = ImmutableDictionary<string, string>.Empty;
+            var tagConverter = new TagValueConverterDelegate((name, value) => value);
+
+            Assert.Throws<InvalidOperationException>(
+                () => metric.GetTags(defaultTags, tagConverter, x => x,new Dictionary<Type, List<MetricTag>>())
+            );
+        }
+
+        [Fact]
+        public void ReadOnlyPropertyReturnsValue()
+        {
+            var metric = new MetricWithTaggedReadOnlyProperty("test");
+            var defaultTags = ImmutableDictionary<string, string>.Empty;
+            var tagConverter = new TagValueConverterDelegate((name, value) => value);
+            var tags = metric.GetTags(defaultTags, tagConverter, x => x, new Dictionary<Type, List<MetricTag>>());
+
+            Assert.True(tags.ContainsKey("Tag"));
+            Assert.Equal("test", tags["Tag"]);
+        }
+
+        [Fact]
+        public void ReadOnlyFieldReturnsValue()
+        {
+            var metric = new MetricWithTaggedReadOnlyField("test");
+            var defaultTags = ImmutableDictionary<string, string>.Empty;
+            var tagConverter = new TagValueConverterDelegate((name, value) => value);
+            var tags = metric.GetTags(defaultTags, tagConverter, x => x, new Dictionary<Type, List<MetricTag>>());
+
+            Assert.True(tags.ContainsKey("Tag"));
+            Assert.Equal("test", tags["Tag"]);
+        }
+
+        [Fact]
+        public void EnumMembersReturnValues()
+        {
+            var metric = new MetricWithTaggedEnumMembers(TagValue.One, TagValue.Two);
+            var defaultTags = ImmutableDictionary<string, string>.Empty;
+            var tagConverter = new TagValueConverterDelegate((name, value) => value);
+            var tags = metric.GetTags(defaultTags, tagConverter, x => x, new Dictionary<Type, List<MetricTag>>());
+
+            Assert.True(tags.ContainsKey("Field"));
+            Assert.Equal("One", tags["Field"]);
+            Assert.True(tags.ContainsKey("Property"));
+            Assert.Equal("Two", tags["Property"]);
+        }
+
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(byte))]
+        [InlineData(typeof(long))]
+        [InlineData(typeof(short))]
+        [InlineData(typeof(double))]
+        [InlineData(typeof(float))]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(CustomStruct))]
+        [InlineData(typeof(CustomClass))]
+        public void InvalidFieldTypesThrow(Type type)
+        {
+            var metricType = typeof(MetricWithInvalidField<>).MakeGenericType(type);
+            var metric = (MetricBase)Activator.CreateInstance(metricType);
+            var defaultTags = ImmutableDictionary<string, string>.Empty;
+            var tagConverter = new TagValueConverterDelegate((name, value) => value);
+
+            Assert.Throws<InvalidOperationException>(
+                () => metric.GetTags(defaultTags, tagConverter, x => x,new Dictionary<Type, List<MetricTag>>())
+            );
+        }
+
+        [Fact]
+        public void CustomTagName()
+        {
+            var metric = new MetricWithCustomNaming("custom-name");
+            var defaultTags = ImmutableDictionary<string, string>.Empty;
+            var tagConverter = new TagValueConverterDelegate((name, value) => value);
+            var tags = metric.GetTags(defaultTags, tagConverter, x => x, new Dictionary<Type, List<MetricTag>>());
+
+            Assert.True(tags.ContainsKey("my-awesome-tag"));
+            Assert.False(tags.ContainsKey("Tag"));
+            Assert.Equal("custom-name", tags["my-awesome-tag"]);
+        }
+
+        [Fact]
+        public void DefaultTagsAreOverridden()
+        {
+            var metric = new MetricWithTaggedReadOnlyProperty("value");
+            var defaultTags = ImmutableDictionary<string, string>.Empty.Add("Tag", "default");
+            var tagConverter = new TagValueConverterDelegate((name, value) => value);
+            var tags = metric.GetTags(defaultTags, tagConverter, x => x, new Dictionary<Type, List<MetricTag>>());
+
+            Assert.True(tags.ContainsKey("Tag"));
+            Assert.Equal("value", tags["Tag"]);
+        }
+
+        [Fact]
+        public void TagValuesAreConverted()
+        {
+            var metric = new MetricWithTaggedReadOnlyProperty("value");
+            var defaultTags = ImmutableDictionary<string, string>.Empty;
+            var tagConverter = new TagValueConverterDelegate((name, value) => value.ToUpper());
+            var tags = metric.GetTags(defaultTags, tagConverter, x => x, new Dictionary<Type, List<MetricTag>>());
+
+            Assert.True(tags.ContainsKey("Tag"));
+            Assert.Equal("VALUE", tags["Tag"]);
+        }
+
+        private abstract class TestMetric : MetricBase
+        {
+            public override MetricType MetricType { get; } = MetricType.Counter;
+
+            protected override void Serialize(IMetricBatch writer, DateTime now)
+            {
+            }
+        }
+
+        private class MetricWithTaggedReadWriteProperty : TestMetric
+        {
+            [MetricTag] public string Tag { get; set; }
+        }
+
+        private class MetricWithTaggedReadWriteField : TestMetric
+        {
+            [MetricTag] public string Tag;
+        }
+
+        private class MetricWithTaggedReadOnlyProperty : TestMetric
+        {
+            public MetricWithTaggedReadOnlyProperty(string tag) => (Tag) = tag;
+
+            [MetricTag] public string Tag { get; }
+        }
+
+        private class MetricWithTaggedReadOnlyField : TestMetric
+        {
+            public MetricWithTaggedReadOnlyField(string tag) => (Tag) = tag;
+
+            [MetricTag] public readonly string Tag;
+        }
+
+        private enum TagValue
+        {
+            One,
+            Two,
+        }
+
+        private class MetricWithTaggedEnumMembers : TestMetric
+        {
+            public MetricWithTaggedEnumMembers(TagValue field, TagValue property) =>
+                (Field, Property) = (field, property);
+
+            [MetricTag] public readonly TagValue Field;
+            [MetricTag] public TagValue Property { get; }
+        }
+
+        private class MetricWithInvalidField<T> : TestMetric
+        {
+            public MetricWithInvalidField()
+            {
+                Tag = default(T);
+            }
+
+            [MetricTag] public readonly T Tag;
+        }
+
+        private class CustomClass
+        {
+        }
+
+        private struct CustomStruct
+        {
+        }
+
+        private class MetricWithCustomNaming : TestMetric
+        {
+            public MetricWithCustomNaming(string tag) => (Tag) = (tag);
+            [MetricTag(name: "my-awesome-tag")]
+            public string Tag { get; }
+        }
+    }
+}


### PR DESCRIPTION
This is intended to partially address some parts of #33 by introducing support for annotating `get`-only properties with `MetricTag` in addition to `readonly` fields.

Also adds tests to ensure everything works as intended!