### PR TITLE
Add tests for `DiagnosticsCollector` and `IMetricSet` implementations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
       with:
           dotnet-version: '3.1.201'
     - name: .NET Build
-      run: dotnet build Build.csproj -c Release /p:CI=true
+      run: dotnet build Build.csproj -c Release --nologo /p:CI=true
     - name: .NET Test
-      run: dotnet test Build.csproj -c Release --no-build /p:CI=true
+      run: dotnet test Build.csproj -c Release --no-build --nologo /p:CI=true
   build-windows:
     runs-on: windows-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
@@ -32,6 +32,6 @@ jobs:
       with:
         fetch-depth: 0
     - name: .NET Build
-      run: dotnet build Build.csproj -c Release /p:CI=true
+      run: dotnet build Build.csproj -c Release --nologo /p:CI=true
     - name: .NET Test
-      run: dotnet test Build.csproj -c Release --no-build /p:CI=true
+      run: dotnet test Build.csproj -c Release --no-build --nologo /p:CI=true

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -20,9 +20,9 @@ jobs:
       with:
           dotnet-version: '3.1.201'
     - name: .NET Build
-      run: dotnet build Build.csproj -c Release /p:CI=true
+      run: dotnet build Build.csproj -c Release --nologo /p:CI=true
     - name: .NET Test
-      run: dotnet test Build.csproj -c Release --no-build /p:CI=true
+      run: dotnet test Build.csproj -c Release --no-build --nologo /p:CI=true
   build-windows:
     needs: build-ubuntu
     runs-on: windows-latest
@@ -33,10 +33,10 @@ jobs:
       with:
         fetch-depth: 0
     - name: .NET Build
-      run: dotnet build Build.csproj -c Release /p:CI=true
+      run: dotnet build Build.csproj -c Release --nologo /p:CI=true
     - name: .NET Test
-      run: dotnet test Build.csproj -c Release --no-build /p:CI=true
+      run: dotnet test Build.csproj -c Release --no-build --nologo /p:CI=true
     - name: .NET Pack
-      run: dotnet pack Build.csproj --no-build -c Release /p:PackageOutputPath=${env:GITHUB_WORKSPACE}\.nupkgs /p:CI=true
+      run: dotnet pack Build.csproj --no-build -c Release --nologo /p:PackageOutputPath=${env:GITHUB_WORKSPACE}\.nupkgs /p:CI=true
     - name: Push to MyGet
-      run: dotnet nuget push ${env:GITHUB_WORKSPACE}\.nupkgs\*.nupkg -s https://www.myget.org/F/stackoverflow/api/v2/package -k ${{ secrets.MYGET_API_KEY }}
+      run: dotnet nuget push ${env:GITHUB_WORKSPACE}\.nupkgs\*.nupkg -s https://www.myget.org/F/stackoverflow/api/v2/package -k ${{ secrets.MYGET_API_KEY }} --nologo

--- a/src/StackExchange.Metrics/DependencyInjection/MetricsCollectorBuilderExtensions.cs
+++ b/src/StackExchange.Metrics/DependencyInjection/MetricsCollectorBuilderExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds a Bosun endpoint to the collector.
         /// </summary>
-        public static IMetricsCollectorBuilder AddBosunEndpoint(this IMetricsCollectorBuilder builder, Uri baseUri, Action<BosunMetricHandler> configure)
+        public static IMetricsCollectorBuilder AddBosunEndpoint(this IMetricsCollectorBuilder builder, Uri baseUri, Action<BosunMetricHandler> configure = null)
         {
             var handler = new BosunMetricHandler(baseUri);
             configure?.Invoke(handler);

--- a/tests/StackExchange.Metrics.Tests/DiagnosticsCollectorTests.cs
+++ b/tests/StackExchange.Metrics.Tests/DiagnosticsCollectorTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Extensions.Hosting;
+using StackExchange.Metrics.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Metrics.Tests
+{
+    public class DiagnosticsCollectorTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public DiagnosticsCollectorTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task CounterCallbacksAreFired()
+        {
+            // spin up a diagnostics collector
+            var diagnosticsCollector = new DiagnosticsCollector(new TestOutputLogger<DiagnosticsCollector>(_output));
+
+            // listen for our custom event source
+            diagnosticsCollector.AddSource(
+                new EventPipeProvider(
+                    CustomEventSource.SourceName,
+                    EventLevel.LogAlways,
+                    0,
+                    arguments: new Dictionary<string, string>()
+                    {
+                        { "EventCounterIntervalSec", "1" }
+                    }
+                )
+            );
+
+            // add a callback for our counters
+            var callCount = 0;
+            var resetEvent = new AutoResetEvent(false);
+            diagnosticsCollector.AddCounterCallback(
+                CustomEventSource.SourceName,
+                CustomEventSource.CounterName,
+                v =>
+                {
+                    Interlocked.Increment(ref callCount);
+                    resetEvent.Set();
+                }
+            );
+
+            // kick off the diagnostics collector
+            await ((IHostedService)diagnosticsCollector).StartAsync(CancellationToken.None);
+
+            // increment one of our counters to kick off event processing
+            CustomEventSource.Instance.IncrementCounter();
+
+            // wait until the collector starts processing events
+            await diagnosticsCollector.WaitUntilProcessing();
+
+            try
+            {
+                // we should have received one event here
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)));
+                Assert.Equal(1, callCount);
+
+                // increment the counter
+                CustomEventSource.Instance.IncrementCounter();
+
+                // shoulda received another event!
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)));
+                Assert.Equal(2, callCount);
+            }
+            finally
+            {
+                await ((IHostedService) diagnosticsCollector).StopAsync(CancellationToken.None);
+            }
+        }
+
+        [Fact]
+        public async Task GaugeCallbacksAreFired()
+        {
+            // spin up a diagnostics collector
+            var diagnosticsCollector = new DiagnosticsCollector(new TestOutputLogger<DiagnosticsCollector>(_output));
+
+            // listen for our custom event source
+            diagnosticsCollector.AddSource(
+                new EventPipeProvider(
+                    CustomEventSource.SourceName,
+                    EventLevel.LogAlways,
+                    0,
+                    arguments: new Dictionary<string, string>()
+                    {
+                        { "EventCounterIntervalSec", "1" }
+                    }
+                )
+            );
+
+            // add a callback for our counters
+            var callCount = 0;
+            var resetEvent = new AutoResetEvent(false);
+            diagnosticsCollector.AddGaugeCallback(
+                CustomEventSource.SourceName,
+                CustomEventSource.GaugeName,
+                v =>
+                {
+                    Interlocked.Increment(ref callCount);
+                    resetEvent.Set();
+                }
+            );
+
+            // kick off the diagnostics collector
+            await ((IHostedService)diagnosticsCollector).StartAsync(CancellationToken.None);
+
+            // update the gauge to kick off event processing
+            CustomEventSource.Instance.UpdateGauge();
+
+            // wait until the collector starts processing events
+            await diagnosticsCollector.WaitUntilProcessing();
+
+            try
+            {
+                // we should have received one event here
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)));
+                Assert.Equal(1, callCount);
+
+                // update the gauge
+                CustomEventSource.Instance.UpdateGauge();
+
+                // shoulda received another event!
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)));
+                Assert.Equal(2, callCount);
+            }
+            finally
+            {
+                await ((IHostedService) diagnosticsCollector).StopAsync(CancellationToken.None);
+            }
+        }
+
+    }
+
+    [EventSource(Name = SourceName)]
+    public class CustomEventSource : EventSource
+    {
+        private readonly Random _rng;
+        private readonly IncrementingEventCounter _counter;
+        private readonly EventCounter _gauge;
+
+        public const string SourceName = nameof(CustomEventSource);
+        public const string CounterName = "custom-counter";
+        public const string GaugeName = "custom-gauge";
+
+        private static CustomEventSource _instance;
+
+        public static CustomEventSource Instance { get; } = _instance ??= new CustomEventSource();
+
+        public CustomEventSource() : base(nameof(CustomEventSource))
+        {
+            _rng = new Random();
+            _counter = new IncrementingEventCounter(CounterName, this);
+            _gauge = new EventCounter(GaugeName, this);
+        }
+
+        public void IncrementCounter() => _counter.Increment(1);
+
+        public void UpdateGauge() => _gauge.WriteMetric(_rng.NextDouble() * 100);
+    }
+}

--- a/tests/StackExchange.Metrics.Tests/DiagnosticsCollectorTests.cs
+++ b/tests/StackExchange.Metrics.Tests/DiagnosticsCollectorTests.cs
@@ -64,14 +64,14 @@ namespace StackExchange.Metrics.Tests
             try
             {
                 // we should have received one event here
-                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)));
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)), "Did not receive initial counter metric value");
                 Assert.Equal(1, callCount);
 
                 // increment the counter
                 CustomEventSource.Instance.IncrementCounter();
 
                 // shoulda received another event!
-                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)));
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(2)), "Did not receive updated counter metric value");
                 Assert.Equal(2, callCount);
             }
             finally
@@ -124,14 +124,14 @@ namespace StackExchange.Metrics.Tests
             try
             {
                 // we should have received one event here
-                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)));
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)), "Did not receive initial gauge metric value");
                 Assert.Equal(1, callCount);
 
                 // update the gauge
                 CustomEventSource.Instance.UpdateGauge();
 
                 // shoulda received another event!
-                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)));
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(2)), "Did not receive updated gauge metric value");
                 Assert.Equal(2, callCount);
             }
             finally

--- a/tests/StackExchange.Metrics.Tests/DiagnosticsCollectorTests.cs
+++ b/tests/StackExchange.Metrics.Tests/DiagnosticsCollectorTests.cs
@@ -64,14 +64,14 @@ namespace StackExchange.Metrics.Tests
             try
             {
                 // we should have received one event here
-                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)), "Did not receive initial counter metric value");
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(5)), "Did not receive initial counter metric value");
                 Assert.Equal(1, callCount);
 
                 // increment the counter
                 CustomEventSource.Instance.IncrementCounter();
 
                 // shoulda received another event!
-                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(2)), "Did not receive updated counter metric value");
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(5)), "Did not receive updated counter metric value");
                 Assert.Equal(2, callCount);
             }
             finally
@@ -124,14 +124,14 @@ namespace StackExchange.Metrics.Tests
             try
             {
                 // we should have received one event here
-                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(1)), "Did not receive initial gauge metric value");
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(5)), "Did not receive initial gauge metric value");
                 Assert.Equal(1, callCount);
 
                 // update the gauge
                 CustomEventSource.Instance.UpdateGauge();
 
                 // shoulda received another event!
-                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(2)), "Did not receive updated gauge metric value");
+                Assert.True(resetEvent.WaitOne(TimeSpan.FromSeconds(5)), "Did not receive updated gauge metric value");
                 Assert.Equal(2, callCount);
             }
             finally

--- a/tests/StackExchange.Metrics.Tests/MetricSetTests.cs
+++ b/tests/StackExchange.Metrics.Tests/MetricSetTests.cs
@@ -79,7 +79,7 @@ namespace StackExchange.Metrics.Tests
                 }
             );
 
-            Assert.True(exceptionThrown.Wait(TimeSpan.FromMilliseconds(200)), "Exception handler was not invoked");
+            Assert.True(exceptionThrown.Wait(TimeSpan.FromSeconds(1)), "Exception handler was not invoked");
         }
 
         private class TestMetricSet : IMetricSet

--- a/tests/StackExchange.Metrics.Tests/MetricSetTests.cs
+++ b/tests/StackExchange.Metrics.Tests/MetricSetTests.cs
@@ -29,11 +29,11 @@ namespace StackExchange.Metrics.Tests
             try
             {
                 // make sure initialization happened
-                await Task.WhenAny(metricSet.InitializeTask, Task.Delay(100));
+                await Task.WhenAny(metricSet.InitializeTask, Task.Delay(1000));
                 Assert.True(metricSet.InitializeTask.IsCompleted, "Metric set was not initialized");
 
                 // and then make sure we actually got snapshotted!
-                await Task.WhenAny(metricSet.SnapshotTask, Task.Delay(100));
+                await Task.WhenAny(metricSet.SnapshotTask, Task.Delay(1000));
                 Assert.True(metricSet.SnapshotTask.IsCompleted, "Metric set was not snapshotted");
             }
             finally

--- a/tests/StackExchange.Metrics.Tests/MetricSetTests.cs
+++ b/tests/StackExchange.Metrics.Tests/MetricSetTests.cs
@@ -82,26 +82,6 @@ namespace StackExchange.Metrics.Tests
             Assert.True(exceptionThrown.Wait(TimeSpan.FromSeconds(1)), "Exception handler was not invoked");
         }
 
-        private class TestMetricSet : IMetricSet
-        {
-            private readonly TaskCompletionSource<object> _initializeTask;
-            private readonly TaskCompletionSource<object> _snapshotTask;
-
-            public Task InitializeTask => _initializeTask.Task;
-
-            public Task SnapshotTask => _snapshotTask.Task;
-
-            public TestMetricSet()
-            {
-                _initializeTask = new TaskCompletionSource<object>();
-                _snapshotTask = new TaskCompletionSource<object>();
-            }
-
-            public void Initialize(IMetricsCollector collector) => _initializeTask.TrySetResult(null);
-
-            public void Snapshot() => _snapshotTask.TrySetResult(null);
-        }
-
         private class FailureMetricSet : IMetricSet
         {
             private readonly bool _throwOnInitialize;

--- a/tests/StackExchange.Metrics.Tests/MetricSetTests.cs
+++ b/tests/StackExchange.Metrics.Tests/MetricSetTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using StackExchange.Metrics.Handlers;
+using StackExchange.Metrics.Infrastructure;
+using Xunit;
+
+namespace StackExchange.Metrics.Tests
+{
+    public class MetricSetTests
+    {
+        [Fact]
+        public async Task MetricSetsAreReported()
+        {
+            var metricSet = new TestMetricSet();
+            var collector = new MetricsCollector(
+                new MetricsCollectorOptions
+                {
+                    Endpoints = new []
+                    {
+                        new MetricEndpoint("Local", new LocalMetricHandler()),
+                    },
+                    Sets = new[] { metricSet },
+                    RetryInterval = TimeSpan.Zero,
+                    SnapshotInterval = TimeSpan.FromMilliseconds(20),
+                }
+            );
+
+            try
+            {
+                // make sure initialization happened
+                await Task.WhenAny(metricSet.InitializeTask, Task.Delay(100));
+                Assert.True(metricSet.InitializeTask.IsCompleted, "Metric set was not initialized");
+
+                // and then make sure we actually got snapshotted!
+                await Task.WhenAny(metricSet.SnapshotTask, Task.Delay(100));
+                Assert.True(metricSet.SnapshotTask.IsCompleted, "Metric set was not snapshotted");
+            }
+            finally
+            {
+                collector.Shutdown();
+            }
+        }
+
+        [Fact]
+        public void ExceptionInInitialize_Throws()
+        {
+            var metricSet = new FailureMetricSet(throwOnInitialize: true);
+
+            Assert.Throws<Exception>(
+                () =>
+                {
+                    new MetricsCollector(
+                        new MetricsCollectorOptions
+                        {
+                            Endpoints = new[] {new MetricEndpoint("Local", new LocalMetricHandler()),},
+                            Sets = new[] {metricSet},
+                            RetryInterval = TimeSpan.Zero,
+                            SnapshotInterval = TimeSpan.FromMilliseconds(20),
+                        }
+                    );
+                }
+            );
+        }
+
+        [Fact]
+        public async Task ExceptionInSnapshot_IsHandled()
+        {
+            var exceptionThrown = new ManualResetEventSlim(false);
+            var metricSet = new FailureMetricSet(throwOnSnapshot: true);
+            var collector = new MetricsCollector(
+                new MetricsCollectorOptions
+                {
+                    Endpoints = new[] {new MetricEndpoint("Local", new LocalMetricHandler()),},
+                    Sets = new[] {metricSet},
+                    RetryInterval = TimeSpan.Zero,
+                    SnapshotInterval = TimeSpan.FromMilliseconds(20),
+                    ExceptionHandler = ex => exceptionThrown.Set()
+                }
+            );
+
+            Assert.True(exceptionThrown.Wait(TimeSpan.FromMilliseconds(200)), "Exception handler was not invoked");
+        }
+
+        private class TestMetricSet : IMetricSet
+        {
+            private readonly TaskCompletionSource<object> _initializeTask;
+            private readonly TaskCompletionSource<object> _snapshotTask;
+
+            public Task InitializeTask => _initializeTask.Task;
+
+            public Task SnapshotTask => _snapshotTask.Task;
+
+            public TestMetricSet()
+            {
+                _initializeTask = new TaskCompletionSource<object>();
+                _snapshotTask = new TaskCompletionSource<object>();
+            }
+
+            public void Initialize(IMetricsCollector collector) => _initializeTask.TrySetResult(null);
+
+            public void Snapshot() => _snapshotTask.TrySetResult(null);
+        }
+
+        private class FailureMetricSet : IMetricSet
+        {
+            private readonly bool _throwOnInitialize;
+            private readonly bool _throwOnSnapshot;
+
+            public FailureMetricSet(bool throwOnInitialize = false, bool throwOnSnapshot = false)
+            {
+                _throwOnInitialize = throwOnInitialize;
+                _throwOnSnapshot = throwOnSnapshot;
+            }
+
+            public void Initialize(IMetricsCollector collector)
+            {
+                if (_throwOnInitialize) throw new Exception("Arghhhhh! Initialization blew up!");
+            }
+
+            public void Snapshot()
+            {
+                if (_throwOnSnapshot) throw new Exception("Arghhhhh! Snapshot blew up!");
+            }
+        }
+    }
+}

--- a/tests/StackExchange.Metrics.Tests/MetricsCollectorBuilderTests.cs
+++ b/tests/StackExchange.Metrics.Tests/MetricsCollectorBuilderTests.cs
@@ -1,0 +1,201 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using StackExchange.Metrics.DependencyInjection;
+using StackExchange.Metrics.Handlers;
+using StackExchange.Metrics.Infrastructure;
+using StackExchange.Metrics.Metrics;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Metrics.Tests
+{
+    public class MetricsCollectorBuilderTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public MetricsCollectorBuilderTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Endpoints_LocalAddedByDefault()
+        {
+            var options = CreateOptions();
+
+            Assert.Contains(options.Endpoints, e => e.Handler is LocalMetricHandler);
+        }
+
+        [Fact]
+        public void Endpoints_AreAdded()
+        {
+            var options = CreateOptions(
+                builder => builder.AddEndpoint("Test", new TestMetricHandler((handler, type, buffer) => default))
+            );
+
+            Assert.Contains(options.Endpoints, e => e.Name == "Test" && e.Handler is TestMetricHandler);
+        }
+
+        [Fact]
+        public void Endpoints_BosunAdded()
+        {
+            var baseUri = new Uri("http://localhost");
+            var options = CreateOptions(
+                builder => builder.AddBosunEndpoint(baseUri)
+            );
+
+            Assert.Contains(options.Endpoints, e => e.Name == "Bosun" && e.Handler is BosunMetricHandler bosunHandler && bosunHandler.BaseUri == baseUri);
+        }
+
+        [Fact]
+        public void Endpoints_SignalFxAdded()
+        {
+            var baseUri = new Uri("http://localhost");
+            var options = CreateOptions(
+                builder => builder.AddSignalFxEndpoint(baseUri)
+            );
+
+            Assert.Contains(options.Endpoints, e => e.Name == "SignalFx" && e.Handler is SignalFxMetricHandler signalFxHandler && signalFxHandler.BaseUri == baseUri);
+        }
+
+        [Fact]
+        public void Sets_Added()
+        {
+            var metricSet = new TestMetricSet();
+            var options = CreateOptions(
+                builder => builder.AddSet(metricSet)
+            );
+
+            Assert.Contains(options.Sets, x => ReferenceEquals(x, metricSet));
+        }
+
+        [Fact]
+        public void Sets_RuntimeSetAdded()
+        {
+            var options = CreateOptions(
+                builder => builder.AddRuntimeMetricSet()
+            );
+
+            Assert.Contains(options.Sets, x => x is RuntimeMetricSet);
+        }
+
+        [Fact]
+        public void Sets_ProcessSetAdded()
+        {
+            var options = CreateOptions(
+                builder => builder.AddProcessMetricSet()
+            );
+
+            Assert.Contains(options.Sets, x => x is ProcessMetricSet);
+        }
+
+        [Fact]
+        public void Sets_AspNetSetAdded()
+        {
+            var options = CreateOptions(
+                builder => builder.AddAspNetMetricSet()
+            );
+
+            Assert.Contains(options.Sets, x => x is AspNetMetricSet);
+        }
+
+        [Fact]
+        public void Sets_DefaultSetsAdded()
+        {
+            var options = CreateOptions(
+                builder => builder.AddDefaultSets()
+            );
+
+            Assert.Contains(options.Sets, x => x is AspNetMetricSet);
+            Assert.Contains(options.Sets, x => x is RuntimeMetricSet);
+            Assert.Contains(options.Sets, x => x is ProcessMetricSet);
+        }
+
+        [Fact]
+        public void Tags_HostTagAddedByDefault()
+        {
+            var options = CreateOptions();
+
+            Assert.Contains(options.DefaultTags, x => x.Key == "host" && x.Value == NameTransformers.Sanitize(Environment.MachineName));
+        }
+
+        [Fact]
+        public void Tags_HostTagCanBeOverridden()
+        {
+            var options = CreateOptions(
+                builder => builder.AddDefaultTag("host", "bob")
+            );
+
+            Assert.Contains(options.DefaultTags, x => x.Key == "host" && x.Value == "bob");
+        }
+
+        [Fact]
+        public void Tags_DefaultTagCanBeAdded()
+        {
+            var options = CreateOptions(
+                builder => builder.AddDefaultTag("name", "value")
+            );
+
+            Assert.Contains(options.DefaultTags, x => x.Key == "name" && x.Value == "value");
+        }
+
+        [Fact]
+        public void ExceptionHandler_IsConfigured()
+        {
+            var handler = new Action<Exception>(ex => _output.WriteLine(ex.ToString()));
+
+            var options = CreateOptions(
+                builder => builder.UseExceptionHandler(handler)
+            );
+
+            Assert.StrictEqual(handler, options.ExceptionHandler);
+        }
+
+        [Fact]
+        public void Configure_ChangesSettings()
+        {
+            var tagValueConverter = new TagValueConverterDelegate((name, value) => value);
+            var tagNameConverter = new Func<string, string>(x => x);
+            var options = CreateOptions(
+                builder => builder.Configure(
+                    o =>
+                    {
+                        o.FlushInterval = TimeSpan.Zero;
+                        o.MetricsNamePrefix = "tests.";
+                        o.PropertyToTagName = tagNameConverter;
+                        o.RetryInterval = TimeSpan.Zero;
+                        o.SnapshotInterval = TimeSpan.Zero;
+                        o.TagValueConverter = tagValueConverter;
+                        o.ThrowOnPostFail = true;
+                        o.ThrowOnQueueFull = true;
+                    })
+            );
+
+            Assert.Equal(TimeSpan.Zero, options.FlushInterval);
+            Assert.Equal("tests.", options.MetricsNamePrefix);
+            Assert.StrictEqual(tagNameConverter, options.PropertyToTagName);
+            Assert.Equal(TimeSpan.Zero, options.RetryInterval);
+            Assert.Equal(TimeSpan.Zero, options.SnapshotInterval);
+            Assert.StrictEqual(tagValueConverter, options.TagValueConverter);
+            Assert.True(options.ThrowOnQueueFull);
+            Assert.True(options.ThrowOnPostFail);
+
+        }
+
+        private MetricsCollectorOptions CreateOptions(Action<IMetricsCollectorBuilder> configure = null)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ITestOutputHelper>(_output);
+            services.AddSingleton(typeof(ILogger<>), typeof(TestOutputLogger<>));
+            services.AddSingleton<IDiagnosticsCollector, DiagnosticsCollector>();
+
+            var builder = new MetricsCollectorBuilder(services);
+
+            configure?.Invoke(builder);
+
+            var serviceProvider = services.BuildServiceProvider();
+            return builder.Build(serviceProvider);
+        }
+    }
+}

--- a/tests/StackExchange.Metrics.Tests/ServiceCollectionTests.cs
+++ b/tests/StackExchange.Metrics.Tests/ServiceCollectionTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using StackExchange.Metrics.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Metrics.Tests
+{
+    public class ServiceCollectionTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ServiceCollectionTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void MetricsCollector_IsAddedAsSingleton()
+        {
+            var services = CreateServices();
+            services.AddMetricsCollector();
+
+            Assert.Contains(
+                services,
+                descriptor => descriptor.Lifetime == ServiceLifetime.Singleton &&
+                              descriptor.ServiceType == typeof(MetricsCollector)
+            );
+
+            Assert.Contains(
+                services,
+                descriptor => descriptor.Lifetime == ServiceLifetime.Singleton &&
+                              descriptor.ServiceType == typeof(IMetricsCollector)
+            );
+        }
+
+        [Fact]
+        public void DiagnosticsCollector_IsAddedAsSingleton()
+        {
+            var services = CreateServices();
+            services.AddMetricsCollector();
+
+            Assert.Contains(
+                services,
+                descriptor => descriptor.Lifetime == ServiceLifetime.Singleton &&
+                              descriptor.ServiceType == typeof(DiagnosticsCollector)
+            );
+
+            Assert.Contains(
+                services,
+                descriptor => descriptor.Lifetime == ServiceLifetime.Singleton &&
+                              descriptor.ServiceType == typeof(IDiagnosticsCollector)
+            );
+        }
+
+        [Fact]
+        public void MetricsCollectorOptions_IsAddedAsSingleton()
+        {
+            var services = CreateServices();
+            services.AddMetricsCollector();
+
+            Assert.Contains(
+                services,
+                descriptor => descriptor.Lifetime == ServiceLifetime.Singleton &&
+                              descriptor.ServiceType == typeof(IOptions<MetricsCollectorOptions>)
+            );
+        }
+
+        [Fact]
+        public void MetricsService_IsAddedAsSingleton()
+        {
+            var services = CreateServices();
+            services.AddMetricsCollector();
+
+            Assert.Contains(
+                services,
+                descriptor => descriptor.Lifetime == ServiceLifetime.Singleton &&
+                              descriptor.ServiceType == typeof(MetricsService)
+            );
+        }
+
+        [Fact]
+        public void MetricsService_IsAddedAsHostedService()
+        {
+            var services = CreateServices();
+            services.AddMetricsCollector();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var hostedServices = serviceProvider.GetServices<IHostedService>();
+
+            Assert.Contains(hostedServices, x => x is MetricsService);
+        }
+
+        [Fact]
+        public void DiagnosticsCollector_IsAddedAsHostedService()
+        {
+            var services = CreateServices();
+            services.AddMetricsCollector();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var hostedServices = serviceProvider.GetServices<IHostedService>();
+
+            Assert.Contains(hostedServices, x => x is DiagnosticsCollector);
+        }
+
+        private ServiceCollection CreateServices()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ITestOutputHelper>(_output);
+            services.AddSingleton(typeof(ILogger<>), typeof(TestOutputLogger<>));
+            return services;
+        }
+    }
+}

--- a/tests/StackExchange.Metrics.Tests/StackExchange.Metrics.Tests.csproj
+++ b/tests/StackExchange.Metrics.Tests/StackExchange.Metrics.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/StackExchange.Metrics.Tests/StackExchange.Metrics.Tests.csproj
+++ b/tests/StackExchange.Metrics.Tests/StackExchange.Metrics.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\StackExchange.Metrics\StackExchange.Metrics.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/StackExchange.Metrics.Tests/TestMetricSet.cs
+++ b/tests/StackExchange.Metrics.Tests/TestMetricSet.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using StackExchange.Metrics.Infrastructure;
+
+namespace StackExchange.Metrics.Tests
+{
+    public class TestMetricSet : IMetricSet
+    {
+        private readonly TaskCompletionSource<object> _initializeTask;
+        private readonly TaskCompletionSource<object> _snapshotTask;
+
+        public Task InitializeTask => _initializeTask.Task;
+
+        public Task SnapshotTask => _snapshotTask.Task;
+
+        public TestMetricSet()
+        {
+            _initializeTask = new TaskCompletionSource<object>();
+            _snapshotTask = new TaskCompletionSource<object>();
+        }
+
+        public void Initialize(IMetricsCollector collector) => _initializeTask.TrySetResult(null);
+
+        public void Snapshot() => _snapshotTask.TrySetResult(null);
+    }
+}

--- a/tests/StackExchange.Metrics.Tests/TestOutputLogger.cs
+++ b/tests/StackExchange.Metrics.Tests/TestOutputLogger.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace StackExchange.Metrics.Tests
+{
+    public class TestOutputLogger<T> : ILogger<T>
+    {
+        private readonly ITestOutputHelper _output;
+
+        public TestOutputLogger(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            => _output.WriteLine(formatter(state, exception));
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable BeginScope<TState>(TState state) => null;
+    }
+}


### PR DESCRIPTION
Add a bunch of tests for new functionality in the forthcoming 2.0 release, notably:

 - `DiagnosticsCollector`
 - `IMetricSets` (and their implement in the collector)
 - `ServiceCollectionExtensions`
 - `MetricsCollectorBuilder`  