### PR TITLE
Use correct counter name for RPS metrics

### DIFF
--- a/src/StackExchange.Metrics/Metrics/AspNetMetricSource.cs
+++ b/src/StackExchange.Metrics/Metrics/AspNetMetricSource.cs
@@ -46,7 +46,7 @@ namespace StackExchange.Metrics.Metrics
                 diagnosticsCollector.AddGaugeCallback(MicrosoftAspNetCoreHostingEventSourceName, eventName, gauge.Record);
             }
 
-            AddCounterCallback("requests-per-sec", "dotnet.kestrel.requests.per_sec", "requests/sec", "Requests per second");
+            AddCounterCallback("requests-per-second", "dotnet.kestrel.requests.per_sec", "requests/sec", "Requests per second");
             AddGaugeCallback("total-requests", "dotnet.kestrel.requests.total", "requests", "Total requests");
             AddGaugeCallback("current-requests", "dotnet.kestrel.requests.current", "requests", "Currently executing requests");
             AddGaugeCallback("failed-requests", "dotnet.kestrel.requests.failed", "requests", "Failed requests");

--- a/src/StackExchange.Metrics/Metrics/RuntimeMetricSource.cs
+++ b/src/StackExchange.Metrics/Metrics/RuntimeMetricSource.cs
@@ -58,7 +58,7 @@ namespace StackExchange.Metrics.Metrics
             }
 
             AddGaugeCallback("cpu-usage", "dotnet.cpu.usage", "percent", "% CPU usage");
-            AddGaugeCallback("working-set", "dotnet.mem.working_set", "megabytes", "Working set for the process");
+            AddGaugeCallback("working-set", "dotnet.mem.working_set", "bytes", "Working set for the process");
 
             // GC
             AddCounterCallback("gen-0-gc-count", "dotnet.mem.collections.gen0", "collections", "Number of gen-0 collections");
@@ -67,7 +67,7 @@ namespace StackExchange.Metrics.Metrics
             AddGaugeCallback("gen-0-size", "dotnet.mem.size.gen0", "bytes", "Total number of bytes in gen-0");
             AddGaugeCallback("gen-1-size", "dotnet.mem.size.gen1", "bytes", "Total number of bytes in gen-1");
             AddGaugeCallback("gen-2-size", "dotnet.mem.size.gen2", "bytes", "Total number of bytes in gen-2");
-            AddGaugeCallback("gc-heap-size", "dotnet.mem.size.heap", "megabytes", "Total number of bytes across all heaps");
+            AddGaugeCallback("gc-heap-size", "dotnet.mem.size.heap", "bytes", "Total number of bytes across all heaps");
             AddGaugeCallback("loh-size", "dotnet.mem.size.loh", "bytes", "Total number of bytes in the LOH");
             AddCounterCallback("alloc-rate", "dotnet.mem.allocation_rate", "bytes/sec", "Allocation Rate (Bytes / sec)");
 

--- a/src/StackExchange.Metrics/Metrics/RuntimeMetricSource.cs
+++ b/src/StackExchange.Metrics/Metrics/RuntimeMetricSource.cs
@@ -58,7 +58,7 @@ namespace StackExchange.Metrics.Metrics
             }
 
             AddGaugeCallback("cpu-usage", "dotnet.cpu.usage", "percent", "% CPU usage");
-            AddGaugeCallback("working-set", "dotnet.mem.working_set", "bytes", "Working set for the process");
+            AddGaugeCallback("working-set", "dotnet.mem.working_set", "megabytes", "Working set for the process");
 
             // GC
             AddCounterCallback("gen-0-gc-count", "dotnet.mem.collections.gen0", "collections", "Number of gen-0 collections");
@@ -67,7 +67,7 @@ namespace StackExchange.Metrics.Metrics
             AddGaugeCallback("gen-0-size", "dotnet.mem.size.gen0", "bytes", "Total number of bytes in gen-0");
             AddGaugeCallback("gen-1-size", "dotnet.mem.size.gen1", "bytes", "Total number of bytes in gen-1");
             AddGaugeCallback("gen-2-size", "dotnet.mem.size.gen2", "bytes", "Total number of bytes in gen-2");
-            AddGaugeCallback("gc-heap-size", "dotnet.mem.size.heap", "bytes", "Total number of bytes across all heaps");
+            AddGaugeCallback("gc-heap-size", "dotnet.mem.size.heap", "megabytes", "Total number of bytes across all heaps");
             AddGaugeCallback("loh-size", "dotnet.mem.size.loh", "bytes", "Total number of bytes in the LOH");
             AddCounterCallback("alloc-rate", "dotnet.mem.allocation_rate", "bytes/sec", "Allocation Rate (Bytes / sec)");
 


### PR DESCRIPTION
The correct counter name is `requests-per-second` but we use `requests-per-sec` 
https://github.com/dotnet/aspnetcore/blob/5e791df47fc91cf8d2a1de94b040d8d52fc7ae18/src/Hosting/Hosting/src/Internal/HostingEventSource.cs#L90