### PR TITLE
Fix TaggedMetricFactory constructor params order

### DIFF
--- a/src/StackExchange.Metrics/Infrastructure/TaggedMetricFactory.cs
+++ b/src/StackExchange.Metrics/Infrastructure/TaggedMetricFactory.cs
@@ -16,7 +16,7 @@ namespace StackExchange.Metrics.Infrastructure
         /// <summary>
         /// Used by derived classes to pass the name, description and unit for a tag.
         /// </summary>
-        protected TaggedMetricFactory(string name, string description, string unit, MetricSourceOptions options)
+        protected TaggedMetricFactory(string name, string unit, string description, MetricSourceOptions options)
         {
             if (name == null)
             {


### PR DESCRIPTION
All the implementers end up calling `: base(name, unit, description, options)`, but the constructor's param order requires `name, description, unit, options`.

As the API exposes the same interface, I think it's better to keep it consistent:
<img width="2134" alt="image" src="https://user-images.githubusercontent.com/6250774/147491588-cfc79e7f-a736-46d5-a337-39973a44416c.png">

Here you can see the 5 usages of this constructor:

https://github.com/StackExchange/StackExchange.Metrics/blob/e707564766b67b9ed6cb426f9d38db7a379ec8cf/src/StackExchange.Metrics/Infrastructure/TaggedMetricFactory.Generated.cs#L75-L82

https://github.com/StackExchange/StackExchange.Metrics/blob/e707564766b67b9ed6cb426f9d38db7a379ec8cf/src/StackExchange.Metrics/Infrastructure/TaggedMetricFactory.Generated.cs#L323-L330

https://github.com/StackExchange/StackExchange.Metrics/blob/e707564766b67b9ed6cb426f9d38db7a379ec8cf/src/StackExchange.Metrics/Infrastructure/TaggedMetricFactory.Generated.cs#L578-L585

https://github.com/StackExchange/StackExchange.Metrics/blob/e707564766b67b9ed6cb426f9d38db7a379ec8cf/src/StackExchange.Metrics/Infrastructure/TaggedMetricFactory.Generated.cs#L840-L847

https://github.com/StackExchange/StackExchange.Metrics/blob/e707564766b67b9ed6cb426f9d38db7a379ec8cf/src/StackExchange.Metrics/Infrastructure/TaggedMetricFactory.Generated.cs#L1109-L1116