### PR TITLE
Prevent `MetricQueueFullException` when using no-op `StatsdMetricHandler`

### DIFF
--- a/src/StackExchange.Metrics/Infrastructure/BufferedMetricHandler.cs
+++ b/src/StackExchange.Metrics/Infrastructure/BufferedMetricHandler.cs
@@ -60,7 +60,11 @@ namespace StackExchange.Metrics.Infrastructure
                 payloadMetadata.FlushPositions.Add(startPosition);
             }
 
-            payloadMetadata.PayloadCount++;
+            // only increase payload count if we actually serialized a metric
+            if (endPosition > startPosition)
+            {
+                payloadMetadata.PayloadCount++;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## The issue

`StatsdMetricsHandler` treats serializing metrics as a no-op when you set `Host` or `Port` to `null`/`0`:

https://github.com/StackExchange/StackExchange.Metrics/blob/10a4e97a3263059d08166b42f30ed772ed2eb9c0/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs#L114-L120

We'd love to use this behavior to be able to enable/disable `statsd`-based metrics collection via feature flags. However, we're running into a problem where we're hit with `MetricQueueFullExceptions` when we configure a `StatsdMetricsHandler` with `null`/`0`. The reason seems to be that we always increment the `PayloadCount` on `payloadMetadata`, even if a call to `SerializeMetric()` was effectively a no-op and didn't write anything to the buffer.

https://github.com/StackExchange/StackExchange.Metrics/blob/10a4e97a3263059d08166b42f30ed772ed2eb9c0/src/StackExchange.Metrics/Infrastructure/BufferedMetricHandler.cs#L46-L64

This causes the `BufferedMetricHandler` to wrongly assume that the metric queue is running full over time.

## The fix

In this PR, I check whether we've effectively serialized a metric and only then increment the `PayloadCount`.

I've included 2 tests to demonstrate the issue at hand. I acknowledge that they're somewhat contrived by calling `SerializeMetric()` directly.

## Alternatives

I saw that the `SignalFxMetricHandler` is wrapping an `_activeHandler` internally. That one's then being used to either create a `NoOpMetricHandler` if the `basUri` is set to `null` or to use a `BufferedMetricHandler` otherwise. I think we could use the same pattern for the `StatsdMetricHandler` - but I opted for the solution that requires fewer changes instead.

I'd love to hear whether this is a proper fix for the problem at hand or whether there's another solution I should look at.