### PR TITLE
`StatsdMetricsHandler`: Delegate to `NoOpStatsHandler` when configuring invalid UDP endpoint

### DIFF
--- a/src/StackExchange.Metrics/Handlers/SignalFxMetricHandler.cs
+++ b/src/StackExchange.Metrics/Handlers/SignalFxMetricHandler.cs
@@ -123,7 +123,7 @@ namespace StackExchange.Metrics.Handlers
 
             if (_baseUri.Scheme == "udp")
             {
-                return new StatsdMetricHandler(_baseUri.Host, (ushort)_baseUri.Port);
+                return new BufferedStatsdMetricHandler(_baseUri.Host, (ushort)_baseUri.Port);
             }
 
             if (_baseUri.Scheme == Uri.UriSchemeHttp || _baseUri.Scheme == Uri.UriSchemeHttps)

--- a/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
+++ b/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
@@ -408,8 +408,7 @@ namespace StackExchange.Metrics.Handlers
 
             return FetchSocketArgsAndSendAsync(_clientSocketDataTask, sequence);
 
-            async ValueTask FetchSocketArgsAndSendAsync(ValueTask<ClientSocketData> socketDataTask,
-                ReadOnlySequence<byte> buffer)
+            async ValueTask FetchSocketArgsAndSendAsync(ValueTask<ClientSocketData> socketDataTask, ReadOnlySequence<byte> buffer)
             {
                 await SendMetricAsync(await socketDataTask, buffer);
             }

--- a/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
+++ b/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
@@ -251,8 +251,7 @@ namespace StackExchange.Metrics.Handlers
                 length += s_pipe.Length + s_hash.Length;
                 foreach (var tag in reading.Tags)
                 {
-                    length += encoding.GetByteCount(tag.Key) + s_colon.Length + encoding.GetByteCount(tag.Value) +
-                              s_comma.Length;
+                    length += encoding.GetByteCount(tag.Key) + s_colon.Length + encoding.GetByteCount(tag.Value) + s_comma.Length;
                 }
 
                 // take away the last comma
@@ -279,8 +278,7 @@ namespace StackExchange.Metrics.Handlers
                 var valueBytesWritten = 0;
                 if (valueIsWhole)
                 {
-                    if (!Utf8Formatter.TryFormat((long)reading.Value, buffer.AsSpan(bytesWritten, valueLength),
-                            out valueBytesWritten))
+                    if (!Utf8Formatter.TryFormat((long)reading.Value, buffer.AsSpan(bytesWritten, valueLength), out valueBytesWritten))
                     {
                         var ex = new InvalidOperationException(
                             "Span was not big enough to write metric value"
@@ -292,8 +290,7 @@ namespace StackExchange.Metrics.Handlers
                     }
                 }
                 // write the value as a fixed point (f5) decimal
-                else if (!Utf8Formatter.TryFormat(reading.Value, buffer.AsSpan(bytesWritten, valueLength),
-                             out valueBytesWritten, s_valueFormat))
+                else if (!Utf8Formatter.TryFormat(reading.Value, buffer.AsSpan(bytesWritten, valueLength), out valueBytesWritten, s_valueFormat))
                 {
                     var ex = new InvalidOperationException(
                         "Span was not big enough to write metric value"
@@ -348,8 +345,7 @@ namespace StackExchange.Metrics.Handlers
         /// <inheritdoc />
         protected override PayloadTypeMetadata CreatePayloadTypeMetadata(PayloadType payloadType)
         {
-            PayloadTypeMetadata CreatePayloadTypeMetadata() =>
-                new PayloadTypeMetadata(BufferWriter<byte>.Create(blockSize: MaxPayloadSize));
+            PayloadTypeMetadata CreatePayloadTypeMetadata() => new PayloadTypeMetadata(BufferWriter<byte>.Create(blockSize: MaxPayloadSize));
 
             switch (payloadType)
             {
@@ -383,9 +379,7 @@ namespace StackExchange.Metrics.Handlers
             async ValueTask<ClientSocketData> FetchClientSocketDataAsync()
             {
                 var hostAddresses = await Dns.GetHostAddressesAsync(_host);
-                var hostAddress = hostAddresses.FirstOrDefault(x =>
-                    x.AddressFamily == AddressFamily.InterNetwork ||
-                    x.AddressFamily == AddressFamily.InterNetworkV6);
+                var hostAddress = hostAddresses.FirstOrDefault(x => x.AddressFamily == AddressFamily.InterNetwork || x.AddressFamily == AddressFamily.InterNetworkV6);
                 if (hostAddress == null)
                 {
                     throw new ArgumentException("Unable to find an IPv4 or IPv6 address for host", nameof(_host));

--- a/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
+++ b/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
@@ -37,8 +37,31 @@ namespace StackExchange.Metrics.Handlers
         /// </remarks>
         public StatsdMetricHandler(string host, ushort port)
         {
-            Host = host;
-            Port = port;
+            _host = host;
+            _port = port;
+            _activeHandler = GetHandler();
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum number of payloads we can keep before we consider our buffers full.
+        /// </summary>
+        public long MaxPayloadCount
+        {
+            get
+            {
+                if (_activeHandler is BufferedStatsdMetricHandler bufferedHandler)
+                {
+                    return bufferedHandler.MaxPayloadCount;
+                }
+                return 0;
+            }
+            set
+            {
+                if (_activeHandler is BufferedStatsdMetricHandler bufferedHandler)
+                {
+                    bufferedHandler.MaxPayloadCount = value;
+                }
+            }
         }
 
         /// <summary>
@@ -91,7 +114,7 @@ namespace StackExchange.Metrics.Handlers
         /// <inheritdoc />
         public ValueTask FlushAsync(TimeSpan delayBetweenRetries, int maxRetries, Action<AfterSendInfo> afterSend,
             Action<Exception> exceptionHandler) =>
-            _activeHandler.FlushAsync(delayBetweenRetries, maxRetries, afterSend, exceptionHandler);
+            _activeHandler?.FlushAsync(delayBetweenRetries, maxRetries, afterSend, exceptionHandler) ?? default(ValueTask);
 
         /// <inheritdoc />
         public void Dispose() => _activeHandler.Dispose();

--- a/src/StackExchange.Metrics/MetricsCollectorExtensions.cs
+++ b/src/StackExchange.Metrics/MetricsCollectorExtensions.cs
@@ -46,6 +46,9 @@ namespace StackExchange.Metrics
                     case SignalFxMetricHandler signalFxHandler:
                         await textWriter.WriteLineAsync(signalFxHandler.BaseUri?.AbsoluteUri ?? "null");
                         break;
+                    case StatsdMetricHandler signalFxHandler:
+                        await textWriter.WriteLineAsync(signalFxHandler.Host + " " + signalFxHandler.Port);
+                        break;
                     case LocalMetricHandler h:
                         await textWriter.WriteLineAsync("Local");
                         break;

--- a/src/StackExchange.Metrics/MetricsCollectorExtensions.cs
+++ b/src/StackExchange.Metrics/MetricsCollectorExtensions.cs
@@ -46,8 +46,8 @@ namespace StackExchange.Metrics
                     case SignalFxMetricHandler signalFxHandler:
                         await textWriter.WriteLineAsync(signalFxHandler.BaseUri?.AbsoluteUri ?? "null");
                         break;
-                    case StatsdMetricHandler signalFxHandler:
-                        await textWriter.WriteLineAsync(signalFxHandler.Host + " " + signalFxHandler.Port);
+                    case StatsdMetricHandler statsdHandler:
+                        await textWriter.WriteLineAsync(statsdHandler.Host + ":" + statsdHandler.Port);
                         break;
                     case LocalMetricHandler h:
                         await textWriter.WriteLineAsync("Local");


### PR DESCRIPTION
A more sophisticated attempt at solving the issue outlined in #48.

Similarly to the `SignalFxMetricHandler`, this PR changes the `StatsdMetricHandler` to wrap an internal `_activeHandler` property that either points to an actual `BufferedStatsdMetricHandler` (which is effectively the former `StatsdMetricHandler`) or a `NoOpMetricHandler` if the UDP host/port configuration suggests that we're not pointing to anything reasonable.

This allows users to deactivate the `StatsdMetricHandler` by passing `null`/`0` as `host` and `port` properties, and to activate it by passing a valid UDP endpoint.